### PR TITLE
fix(ci): pin gh actions-cache extension by release tag

### DIFF
--- a/.github/workflows/ai-claude-code-review.yml
+++ b/.github/workflows/ai-claude-code-review.yml
@@ -33,7 +33,6 @@ jobs:
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           disable-sudo: true
-          disable-file-monitoring: true
           egress-policy: audit
 
       - name: Verify Claude settings

--- a/.github/workflows/ai-claude-code-review.yml
+++ b/.github/workflows/ai-claude-code-review.yml
@@ -33,6 +33,7 @@ jobs:
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           disable-sudo: true
+          disable-file-monitoring: true
           egress-policy: audit
 
       - name: Verify Claude settings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Compile plugin for CodeQL
         timeout-minutes: 10
-        run: ./gradlew :plugin:compileKotlin --continue --stacktrace
+        run: ./gradlew :plugin:compileKotlin --rerun-tasks --continue --stacktrace
 
       - name: Perform CodeQL Analysis
         timeout-minutes: 12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,11 @@ jobs:
           sarif_file: build/lint-merged.sarif
           category: lint
 
+      # The root plugin build runs on every OS/JDK leg. The integration builds are
+      # Gradle/Kotlin behavior checks, so run them once on the primary supported JDK
+      # instead of multiplying the same coverage across every matrix leg.
       - name: 'Run check-gradle-plugin'
-        if: always()
+        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
         timeout-minutes: 6
         working-directory: checks/gradle-plugin
         run: ./gradlew build assemble check --continue --stacktrace --scan
@@ -114,7 +117,7 @@ jobs:
           GITHUB_DEPENDENCY_GRAPH_ENABLED: false
 
       - name: 'Run check-kmp'
-        if: always()
+        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
         timeout-minutes: 12
         working-directory: checks/kmp
         run: ./gradlew build assemble check printKotlinSourceSetsGraph --continue --stacktrace --scan
@@ -122,7 +125,7 @@ jobs:
           GITHUB_DEPENDENCY_GRAPH_ENABLED: false
 
       - name: 'Run check-compose-desktop'
-        if: always()
+        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
         timeout-minutes: 14
         working-directory: checks/compose-desktop
         run: ./gradlew build assemble check packageReleaseDistributionForCurrentOS --continue --stacktrace --scan
@@ -130,7 +133,7 @@ jobs:
           GITHUB_DEPENDENCY_GRAPH_ENABLED: false
 
       - name: 'Run check-android'
-        if: always()
+        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
         timeout-minutes: 8
         working-directory: checks/android
         # Non-KMP `com.android.library` integration check exercising the legacy AGP
@@ -143,6 +146,7 @@ jobs:
           GITHUB_DEPENDENCY_GRAPH_ENABLED: false
 
       - name: 'Run self check'
+        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
         timeout-minutes: 4
         working-directory: self
         run: ./gradlew build assemble check --continue --stacktrace --scan

--- a/.github/workflows/pr-clean-cache.yml
+++ b/.github/workflows/pr-clean-cache.yml
@@ -31,12 +31,10 @@ jobs:
           REPO: ${{ github.repository }}
           BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
         run: |
-          # `--pin <SHA>` requires gh 2.41.0+ (GitHub-hosted runners ship newer).
-          # SHA = actions/gh-actions-cache@v1.0.4 (latest stable as of 2024-04).
-          # Bump by resolving the new tag's commit:
-          #   gh api repos/actions/gh-actions-cache/git/refs/tags/<tag> --jq .object.sha
+          # Binary gh extensions are pinned by release tag; commit pins are for
+          # script extensions cloned from source.
           gh extension install actions/gh-actions-cache \
-            --pin d88f49218fd18a37f6f63ee4f8716764316a7f7d
+            --pin v1.0.4
 
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1 )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
     runs-on: macos-latest
     env:
       SCM_TAG: ${{ needs.verify_release.outputs.tag }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
 
     steps:
       - name: Harden Runner
@@ -93,6 +98,10 @@ jobs:
           done
           if (( ${#missing[@]} > 0 )); then
             printf '::error::Missing required release secrets: %s\n' "${missing[*]}"
+            exit 1
+          fi
+          if [[ "$SIGNING_KEY" != *"BEGIN PGP PRIVATE KEY BLOCK"* ]]; then
+            echo "::error::SIGNING_KEY must be the ASCII-armored private PGP key block."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- pin the PR cache cleanup gh extension by release tag instead of commit SHA
- pass release signing material through Gradle project-property env vars so Vanniktech configures an actual signatory
- add an explicit ASCII-armored private-key shape check for `SIGNING_KEY`
- keep branch-protected Build check names while running integration builds only on the primary Ubuntu/JDK 21 leg
- force the CodeQL manual build step to compile Kotlin even on workflow-only or cache-warm PRs

## Verification
- ruby YAML parser loaded `.github/workflows/pr-clean-cache.yml`, `.github/workflows/release.yml`, and `.github/workflows/build.yml`
- actionlint accepted `.github/workflows/pr-clean-cache.yml`, `.github/workflows/release.yml`, and `.github/workflows/build.yml`
- `actions-up --dir .github --recursive --yes --exclude '^anthropics/claude-code-action$' --style sha --mode major --dry-run` reported every non-Claude action is current
- temp `GH_CONFIG_DIR` install of `actions/gh-actions-cache --pin v1.0.4` exposed `list`/`delete` commands
- disposable local PGP key reproduced the release signing failure with only `SIGNING_KEY`
- the same disposable key succeeded for `:plugin:signFluxo-kmp-confPluginMarkerMavenPublication` with `ORG_GRADLE_PROJECT_signingInMemoryKey`

## Context
PR #90's post-close cache cleanup failed because `gh` could not find a binary extension release named by the old commit SHA pin.
The `v0.14.0` release workflow then failed before publication because Vanniktech signing reads Gradle project properties; a non-empty `SIGNING_KEY` env var alone was not enough to create the Gradle signatory.
The previous Build workflow also repeated every integration build across all six OS/JDK legs; this keeps root build portability coverage but stops multiplying the same integration checks.
CodeQL failed on a workflow-only/cache-warm PR because its manual build did not produce analyzable Java/Kotlin source data; rerunning `:plugin:compileKotlin` makes that invariant explicit.
Claude review currently fails inside the pinned Claude action before completing review (`ENOENT: no such file or directory, symlink` plus Bun `directory mismatch`). The attempted workflow workaround was reverted because Claude workflow changes cannot be validated on a PR: the action requires that workflow file to match default branch exactly.
