### PR TITLE
ci(deps): isolate dependency graph submission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           cache-disabled: ${{ matrix.os == 'windows' }} # super slow on Windows.
           cache-encryption-key: "${{ secrets.GRADLE_ENCRYPTION_KEY }}"
           cache-read-only: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
-          dependency-graph: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && 'generate-and-submit' || 'disabled'}}
+          dependency-graph: disabled
           add-job-summary-as-pr-comment: on-failure
           artifact-retention-days: 1
 

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -2,9 +2,6 @@ name: Dependency Submission
 
 on:
   push:
-    branches:
-      - main
-      - dev
     paths-ignore:
       - '**-validation.yml'
       - '**.*ignore'

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,61 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    paths-ignore:
+      - '**-validation.yml'
+      - '**.*ignore'
+      - '**.md'
+      - '**.txt'
+      - '**/actionlint**'
+      - '**/pr-**.yml'
+      - '**/release.yml'
+      - '**dependabot.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  CI: true
+  BUILD_NUMBER: ${{ github.run_number }}
+  SCM_TAG: ${{ github.sha }}
+
+jobs:
+  dependency-submission:
+    name: Submit Gradle dependency graph
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-encryption-key: "${{ secrets.GRADLE_ENCRYPTION_KEY }}"
+          dependency-graph: generate-and-submit
+          dependency-graph-continue-on-failure: false
+          dependency-graph-include-configurations: "^(?!(classpath)).*"
+          dependency-graph-include-projects: "^:(?!(buildSrc|test|check)).*"
+          artifact-retention-days: 1


### PR DESCRIPTION
## Summary
- disables dependency graph submission in the OS/JDK build matrix
- adds a dedicated default-branch dependency submission workflow with contents: write scoped to that workflow
- keeps all non-Claude GitHub Actions pinned at the latest version per actions-up

## Verification
- ruby YAML parser loaded all .github/workflows/*.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build.yml .github/workflows/dependency-submission.yml
- actions-up --dir .github --recursive --yes --exclude '^anthropics/claude-code-action$' --style sha --mode major --dry-run