### PR TITLE
fix(release): ignore blank signing key id

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,54 +105,6 @@ jobs:
           sarif_file: build/lint-merged.sarif
           category: lint
 
-      # The root plugin build runs on every OS/JDK leg. The integration builds are
-      # Gradle/Kotlin behavior checks, so run them once on the primary supported JDK
-      # instead of multiplying the same coverage across every matrix leg.
-      - name: 'Run check-gradle-plugin'
-        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
-        timeout-minutes: 6
-        working-directory: checks/gradle-plugin
-        run: ./gradlew build assemble check --continue --stacktrace --scan
-        env:
-          GITHUB_DEPENDENCY_GRAPH_ENABLED: false
-
-      - name: 'Run check-kmp'
-        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
-        timeout-minutes: 12
-        working-directory: checks/kmp
-        run: ./gradlew build assemble check printKotlinSourceSetsGraph --continue --stacktrace --scan
-        env:
-          GITHUB_DEPENDENCY_GRAPH_ENABLED: false
-
-      - name: 'Run check-compose-desktop'
-        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
-        timeout-minutes: 14
-        working-directory: checks/compose-desktop
-        run: ./gradlew build assemble check packageReleaseDistributionForCurrentOS --continue --stacktrace --scan
-        env:
-          GITHUB_DEPENDENCY_GRAPH_ENABLED: false
-
-      - name: 'Run check-android'
-        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
-        timeout-minutes: 8
-        working-directory: checks/android
-        # Non-KMP `com.android.library` integration check exercising the legacy AGP
-        # `LibraryExtension`-based `setupAndroidCommon` path under AGP 9 (built-in
-        # Kotlin). Lost CI coverage when `checks/kmp` migrated to the AGP-9 KMP+Android
-        # plugin in 0.14.0; restored here so the non-KMP setup line stays falsified
-        # against every plugin/Kotlin/AGP bump.
-        run: ./gradlew build assemble check --continue --stacktrace --scan
-        env:
-          GITHUB_DEPENDENCY_GRAPH_ENABLED: false
-
-      - name: 'Run self check'
-        if: always() && matrix.os == 'ubuntu' && matrix.java == '21'
-        timeout-minutes: 4
-        working-directory: self
-        run: ./gradlew build assemble check --continue --stacktrace --scan
-        env:
-          GITHUB_DEPENDENCY_GRAPH_ENABLED: false
-
       - name: Upload the build report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -179,6 +131,98 @@ jobs:
             github.rest.issues.createComment({
               issue_number: context.issue.number, owner: context.repo.owner, repo: context.repo.repo,
               body: `❌ ${GH_WORKFLOW} [failed](${RUN_URL}) on ${OS}.`,
+            })
+
+  integrationChecks:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: check-gradle-plugin
+            directory: checks/gradle-plugin
+            command: ./gradlew build assemble check --continue --stacktrace --scan
+            timeout: 6
+          - name: check-kmp
+            directory: checks/kmp
+            command: ./gradlew build assemble check printKotlinSourceSetsGraph --continue --stacktrace --scan
+            timeout: 12
+          - name: check-compose-desktop
+            directory: checks/compose-desktop
+            command: ./gradlew build assemble check packageReleaseDistributionForCurrentOS --continue --stacktrace --scan
+            timeout: 14
+          # Keeps the legacy non-KMP Android library path covered after checks/kmp
+          # moved to the AGP-9 KMP+Android plugin line.
+          - name: check-android
+            directory: checks/android
+            command: ./gradlew build assemble check --continue --stacktrace --scan
+            timeout: 8
+          - name: self-check
+            directory: self
+            command: ./gradlew build assemble check --continue --stacktrace --scan
+            timeout: 4
+    name: 'Integration check / ${{ matrix.name }}'
+    timeout-minutes: 18
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, 'ci skip') }}
+    env:
+      GITHUB_DEPENDENCY_GRAPH_ENABLED: false
+      GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: false
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-encryption-key: "${{ secrets.GRADLE_ENCRYPTION_KEY }}"
+          cache-read-only: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+          dependency-graph: disabled
+          add-job-summary-as-pr-comment: on-failure
+          artifact-retention-days: 1
+
+      - name: 'Run ${{ matrix.name }}'
+        timeout-minutes: ${{ matrix.timeout }}
+        working-directory: ${{ matrix.directory }}
+        run: ${{ matrix.command }}
+
+      - name: Upload the integration build report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: '${{ matrix.name }}-build-report'
+          path: |
+            ${{ matrix.directory }}/**/build/logs/
+            ${{ matrix.directory }}/**/build/reports/
+            ${{ matrix.directory }}/**/build/output/
+          compression-level: 9
+
+      - name: "Post result in PR comment"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: github.event_name == 'pull_request' && failure()
+        env:
+          CHECK_NAME: ${{ matrix.name }}
+          GH_WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { CHECK_NAME, GH_WORKFLOW, RUN_URL } = process.env
+            github.rest.issues.createComment({
+              issue_number: context.issue.number, owner: context.repo.owner, repo: context.repo.repo,
+              body: `❌ ${GH_WORKFLOW} [failed](${RUN_URL}) on ${CHECK_NAME}.`,
             })
 
   codeql:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
     env:
       SCM_TAG: ${{ needs.verify_release.outputs.tag }}
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-      ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
       ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -111,6 +110,7 @@ jobs:
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
         run: |
           umask 077
           mkdir -p ~/.gradle
@@ -119,12 +119,14 @@ jobs:
             printf 'gradle.publish.secret=%s\n' "$GRADLE_PUBLISH_SECRET"
             printf 'mavenCentralUsername=%s\n' "$MAVEN_CENTRAL_USERNAME"
             printf 'mavenCentralPassword=%s\n' "$MAVEN_CENTRAL_PASSWORD"
+            if [[ -n "${SIGNING_KEY_ID:-}" ]]; then
+              printf 'signingInMemoryKeyId=%s\n' "$SIGNING_KEY_ID"
+            fi
           } >> ~/.gradle/gradle.properties
 
       - name: Verify release build
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         run: >
           ./gradlew build assemble check
@@ -133,7 +135,6 @@ jobs:
       - name: Validate Plugin Portal publication
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         run: >
           ./gradlew publishPlugins --validate-only
@@ -142,7 +143,6 @@ jobs:
       - name: Publish Maven Central and Plugin Portal
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         run: >
           ./gradlew publishAndReleaseToMavenCentral publishPlugins

--- a/fluxo-kmp-conf/src/main/kotlin/fluxo/conf/dsl/impl/FluxoConfigurationExtensionPublicationImpl.kt
+++ b/fluxo-kmp-conf/src/main/kotlin/fluxo/conf/dsl/impl/FluxoConfigurationExtensionPublicationImpl.kt
@@ -189,7 +189,9 @@ internal interface FluxoConfigurationExtensionPublicationImpl :
                     scmTag = null,
                     signingKey = project.signingKey(),
                     signingKeyId = project.envOrPropValue("SIGNING_KEY_ID")
-                        ?: project.envOrPropValue("signingInMemoryKeyId"),
+                        ?.takeUnless(String::isBlank)
+                        ?: project.envOrPropValue("signingInMemoryKeyId")
+                            ?.takeUnless(String::isBlank),
                     signingPassword = project.envOrPropValue("SIGNING_PASSWORD")
                         ?: project.envOrPropValue("signingInMemoryKeyPassword"),
                     repositoryUserName = project.envOrPropValue("mavenCentralUsername")

--- a/fluxo-kmp-conf/src/main/kotlin/fluxo/conf/pub/SetupPublication.kt
+++ b/fluxo-kmp-conf/src/main/kotlin/fluxo/conf/pub/SetupPublication.kt
@@ -534,7 +534,7 @@ internal fun Project.validateSignedReleaseBeforeRemotePublish(config: FluxoPubli
     }
 }
 
-private fun SigningExtension.configureInMemoryPgpKeys(config: FluxoPublicationConfig) {
+internal fun SigningExtension.configureInMemoryPgpKeys(config: FluxoPublicationConfig) {
     val signingKeyId = config.signingKeyId
     if (signingKeyId.isNullOrBlank()) {
         useInMemoryPgpKeys(config.signingKey, config.signingPassword)
@@ -596,7 +596,7 @@ private const val LOCAL_REPO_PATH = "_/local-repo"
 private const val LOCAL_REPO_NAME = "localDev"
 
 /** Also a plugin name! */
-private const val SIGNING_EXT_NAME = "signing"
+internal const val SIGNING_EXT_NAME = "signing"
 
 internal const val PUBLISHING_EXT_NAME = "publishing"
 

--- a/fluxo-kmp-conf/src/main/kotlin/fluxo/conf/pub/SetupVanniktechPublication.kt
+++ b/fluxo-kmp-conf/src/main/kotlin/fluxo/conf/pub/SetupVanniktechPublication.kt
@@ -118,7 +118,8 @@ internal fun MavenPublishBaseExtension.setupVanniktechPublication(
         // Set Vanniktech's props first as a compatibility measure.
         val extra = p.extensions.extraProperties
         config.signingKey?.let { extra["signingInMemoryKey"] = it }
-        config.signingKeyId?.let { extra["signingInMemoryKeyId"] = it }
+        config.signingKeyId?.takeUnless(String::isBlank)
+            ?.let { extra["signingInMemoryKeyId"] = it }
         config.signingPassword?.let { extra["signingInMemoryKeyPassword"] = it }
 
         p.pluginManager.apply(SIGNING_EXT_NAME)

--- a/fluxo-kmp-conf/src/main/kotlin/fluxo/conf/pub/SetupVanniktechPublication.kt
+++ b/fluxo-kmp-conf/src/main/kotlin/fluxo/conf/pub/SetupVanniktechPublication.kt
@@ -21,6 +21,7 @@ import fluxo.conf.dsl.impl.FluxoConfigurationExtensionImpl
 import fluxo.conf.impl.android.ANDROID_LIB_PLUGIN_ID
 import fluxo.conf.impl.android.DEBUG
 import fluxo.conf.impl.android.RELEASE
+import fluxo.conf.impl.configureExtension
 import fluxo.conf.impl.getByName
 import fluxo.conf.impl.kotlin.KOTLIN_JVM_PLUGIN_ID
 import fluxo.conf.impl.kotlin.KOTLIN_MPP_PLUGIN_ID
@@ -31,6 +32,7 @@ import fluxo.log.w
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.plugins.signing.SigningExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 
 // https://vanniktech.github.io/gradle-maven-publish-plugin/central/
@@ -119,6 +121,13 @@ internal fun MavenPublishBaseExtension.setupVanniktechPublication(
         config.signingKeyId?.let { extra["signingInMemoryKeyId"] = it }
         config.signingPassword?.let { extra["signingInMemoryKeyPassword"] = it }
 
+        p.pluginManager.apply(SIGNING_EXT_NAME)
+        p.configureExtension<SigningExtension>(name = SIGNING_EXT_NAME) {
+            configureInMemoryPgpKeys(config)
+            if (!config.isSnapshot) {
+                isRequired = true
+            }
+        }
         signAllPublications()
     }
 


### PR DESCRIPTION
## Summary
- omit the optional signing key id from release Gradle properties unless it is non-empty
- treat blank signing key ids as absent in publication defaults
- configure Gradle SigningExtension on the Vanniktech publishing path so SIGNING_KEY env signing works

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release yaml ok"'\n- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml\n- actions-up --dir .github --recursive --yes --exclude '^anthropics/claude-code-action$' --style sha --mode major --dry-run\n- disposable in-memory PGP key: SIGNING_KEY set, SIGNING_KEY_ID blank, SIGNING_PASSWORD set ./gradlew :plugin:signFluxo-kmp-confPluginMarkerMavenPublication --no-build-cache --no-configuration-cache --stacktrace\n- ./gradlew :plugin:check --no-build-cache --no-configuration-cache --stacktrace