### PR TITLE
fix(release): normalize armored signing key

### DIFF
--- a/fluxo-kmp-conf/src/main/kotlin/PropsAndEnv.kt
+++ b/fluxo-kmp-conf/src/main/kotlin/PropsAndEnv.kt
@@ -83,8 +83,22 @@ public fun Project.signingKey(): String? {
     // signingInMemoryKey is used by Vanniktech's publishing plugin.
     val key = envOrPropValue("SIGNING_KEY")
         ?: envOrPropValue("signingInMemoryKey")
-    return key?.replace("\\n", "\n")
+    return key?.normalizeSigningKey()
 }
+
+internal fun String.normalizeSigningKey(): String {
+    val normalized = replace("\\n", "\n").trim()
+    val begin = normalized.indexOf(PGP_PRIVATE_KEY_BEGIN)
+    val end = if (begin >= 0) normalized.indexOf(PGP_PRIVATE_KEY_END, begin) else -1
+    return if (end >= 0) {
+        normalized.substring(begin, end + PGP_PRIVATE_KEY_END.length)
+    } else {
+        normalized
+    }
+}
+
+private const val PGP_PRIVATE_KEY_BEGIN = "-----BEGIN PGP PRIVATE KEY BLOCK-----"
+private const val PGP_PRIVATE_KEY_END = "-----END PGP PRIVATE KEY BLOCK-----"
 
 public fun Project?.buildNumberSuffix(default: String = "", delimiter: String = "."): String {
     val n = buildNumber()

--- a/fluxo-kmp-conf/src/test/kotlin/SigningKeyTest.kt
+++ b/fluxo-kmp-conf/src/test/kotlin/SigningKeyTest.kt
@@ -1,0 +1,33 @@
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class SigningKeyTest {
+
+    @Test
+    fun `normalizes escaped newlines`() {
+        assertEquals(PGP_KEY, PGP_KEY.replace("\n", "\\n").normalizeSigningKey())
+    }
+
+    @Test
+    fun `extracts armored private key from wrapped secret`() {
+        val wrapped = """
+            signingInMemoryKey="$PGP_KEY"
+        """.trimIndent()
+
+        assertEquals(PGP_KEY, wrapped.normalizeSigningKey())
+    }
+
+    @Test
+    fun `leaves non armored value unchanged after trimming`() {
+        assertEquals("not-a-key", "  not-a-key  ".normalizeSigningKey())
+    }
+
+    private companion object {
+        private val PGP_KEY = """
+            -----BEGIN PGP PRIVATE KEY BLOCK-----
+            
+            test-key-body
+            -----END PGP PRIVATE KEY BLOCK-----
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Summary
- extracts the exact ASCII-armored private key block before Gradle signing
- preserves escaped-newline support for signing secrets
- adds focused tests for wrapped, escaped, and non-armored values

## Verification
- ./gradlew :plugin:test --tests SigningKeyTest --no-build-cache --no-configuration-cache --stacktrace
- ./gradlew :plugin:check --no-build-cache --no-configuration-cache --stacktrace

This PR is for checks only. After required statuses pass, the branch will be fast-forwarded to dev directly; do not merge with GitHub.