### PR TITLE
ci(build): enable Windows Gradle cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
-          cache-disabled: ${{ matrix.os == 'windows' }} # super slow on Windows.
           cache-encryption-key: "${{ secrets.GRADLE_ENCRYPTION_KEY }}"
           cache-read-only: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
           dependency-graph: disabled


### PR DESCRIPTION
## Summary
- enables Gradle setup caching on Windows build-matrix legs
- preserves the existing required check names, matrix, and Gradle commands

## Evidence
- actionlint passed for build/release workflows
- diff check passed
- actions-up dry run reports non-Claude actions up to date

## Rationale
Recent PR logs showed Ubuntu restoring cached Kotlin/lint/R8/test work while Windows rebuilt the expensive task graph from scratch because caching was explicitly disabled. This keeps coverage intact and lets default-branch runs seed Windows caches for future PR checks.