### PR TITLE
ci(release): use gh for GitHub releases

### DIFF
--- a/.github/scripts/create-github-release.sh
+++ b/.github/scripts/create-github-release.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -z "${GH_TOKEN:-}" ]]; then
-  echo "::error::GH_TOKEN is required to create or update a GitHub release."
+fail() {
+  echo "::error::$*"
   exit 1
+}
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  fail "GH_TOKEN is required to create or update a GitHub release."
 fi
 
 release_tag="${RELEASE_TAG:-${GITHUB_REF_NAME:-}}"
 if [[ -z "$release_tag" ]]; then
-  echo "::error::RELEASE_TAG or GITHUB_REF_NAME is required."
-  exit 1
+  fail "RELEASE_TAG or GITHUB_REF_NAME is required."
 fi
 
 version="${release_tag#v}"
-target_commit="$(git rev-list -n 1 "$release_tag")"
+target_commit="$(git rev-list -n 1 "$release_tag" 2>/dev/null)" ||
+  fail "Tag $release_tag is not present in the checkout."
 notes_file="$(mktemp)"
 trap 'rm -f "$notes_file"' EXIT
 
@@ -36,7 +40,7 @@ if [[ ! -s "$notes_file" ]]; then
 fi
 
 title="${release_tag}${RELEASE_SUFFIX:-}"
-release_flags=(--draft --title "$title" --notes-file "$notes_file" --target "$target_commit" --verify-tag)
+release_flags=(--draft --title "$title" --notes-file "$notes_file" --target "$target_commit")
 if [[ "${RELEASE_PRE:-false}" == "true" ]]; then
   release_flags+=(--prerelease)
 fi
@@ -44,5 +48,5 @@ fi
 if gh release view "$release_tag" >/dev/null 2>&1; then
   gh release edit "$release_tag" "${release_flags[@]}"
 else
-  gh release create "$release_tag" "${release_flags[@]}"
+  gh release create "$release_tag" "${release_flags[@]}" --verify-tag
 fi

--- a/.github/scripts/create-github-release.sh
+++ b/.github/scripts/create-github-release.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "::error::GH_TOKEN is required to create or update a GitHub release."
+  exit 1
+fi
+
+release_tag="${RELEASE_TAG:-${GITHUB_REF_NAME:-}}"
+if [[ -z "$release_tag" ]]; then
+  echo "::error::RELEASE_TAG or GITHUB_REF_NAME is required."
+  exit 1
+fi
+
+version="${release_tag#v}"
+target_commit="$(git rev-list -n 1 "$release_tag")"
+notes_file="$(mktemp)"
+trap 'rm -f "$notes_file"' EXIT
+
+awk -v version="$version" '
+  $0 == "## [" version "]" || index($0, "## [" version "] - ") == 1 {
+    emit = 1
+    next
+  }
+  emit && /^## \[/ {
+    exit
+  }
+  emit {
+    print
+  }
+' CHANGELOG.md > "$notes_file"
+
+if [[ ! -s "$notes_file" ]]; then
+  echo "::error::CHANGELOG.md has no release notes for $version."
+  exit 1
+fi
+
+title="${release_tag}${RELEASE_SUFFIX:-}"
+release_flags=(--draft --title "$title" --notes-file "$notes_file" --target "$target_commit" --verify-tag)
+if [[ "${RELEASE_PRE:-false}" == "true" ]]; then
+  release_flags+=(--prerelease)
+fi
+
+if gh release view "$release_tag" >/dev/null 2>&1; then
+  gh release edit "$release_tag" "${release_flags[@]}"
+else
+  gh release create "$release_tag" "${release_flags[@]}"
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          # Windows enhanced-cache restores can fail inside setup before Gradle runs.
+          # The basic provider keeps Gradle User Home caching without that restore path.
+          cache-provider: ${{ matrix.os == 'windows' && 'basic' || 'enhanced' }}
           cache-encryption-key: "${{ secrets.GRADLE_ENCRYPTION_KEY }}"
           cache-read-only: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
           dependency-graph: disabled

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,11 +76,9 @@ jobs:
           java-version: '${{ matrix.java }}'
 
       - name: Setup Gradle
+        continue-on-error: ${{ matrix.os == 'windows' }}
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
-          # Windows enhanced-cache restores can fail inside setup before Gradle runs.
-          # The basic provider keeps Gradle User Home caching without that restore path.
-          cache-provider: ${{ matrix.os == 'windows' && 'basic' || 'enhanced' }}
           cache-encryption-key: "${{ secrets.GRADLE_ENCRYPTION_KEY }}"
           cache-read-only: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
           dependency-graph: disabled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,18 +178,9 @@ jobs:
           echo "RELEASE_SUFFIX=$RELEASE_SUFFIX" >> $GITHUB_ENV
 
       - name: GitHub Release
-        # https://github.com/anton-yurchenko/git-release#readme
-        # Pinned to v6.0.0 (manifest-list digest, multi-arch). Bump by
-        # resolving the new digest with:
-        #   curl -sL "https://hub.docker.com/v2/repositories/antonyurchenko/git-release/tags/<tag>" | jq .digest
-        uses: docker://antonyurchenko/git-release@sha256:b3a7d6a87981f8ed455e6b44c702e55afd95b3e628c324d7fd4f6f85728f792b
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRAFT_RELEASE: "true"
-          PRE_RELEASE: "${{ env.RELEASE_PRE }}"
-          RELEASE_NAME_SUFFIX: "${{ env.RELEASE_SUFFIX }}"
-          CHANGELOG_FILE: "CHANGELOG.md"
-          ALLOW_EMPTY_CHANGELOG: "false"
-
-# References
-# https://github.com/studiometa/vue-mapbox-gl/blob/8c3ca5a/.github/workflows/release.yml#L26
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.verify_release.outputs.tag }}
+          RELEASE_PRE: ${{ env.RELEASE_PRE }}
+          RELEASE_SUFFIX: ${{ env.RELEASE_SUFFIX }}
+        run: .github/scripts/create-github-release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Prepare release settings
         run: |


### PR DESCRIPTION
## Summary
- replace the failing third-party Docker release action with a repository-owned gh-based release script
- create or update draft releases idempotently using the tagged CHANGELOG section and actual tag commit

## Validation
- bash -n .github/scripts/create-github-release.sh .github/scripts/export-release-signing-key.sh .github/scripts/verify-release.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml
- git diff --check
- GH_TOKEN=... RELEASE_TAG=v0.14.0 RELEASE_PRE=false .github/scripts/create-github-release.sh