### PR TITLE
ci(claude): update action for symlink restore

### DIFF
--- a/.github/workflows/ai-claude-code-review.yml
+++ b/.github/workflows/ai-claude-code-review.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         timeout-minutes: 32
-        uses: anthropics/claude-code-action@23e4ee05df2c5aefd801f51b83c81cd4215be7e9 # v1.0.120
+        uses: anthropics/claude-code-action@d2b7d924ec4af238380e490a0d57ce6bcc85ce8d # v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/ai-claude-comment.yml
+++ b/.github/workflows/ai-claude-comment.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         timeout-minutes: 32
-        uses: anthropics/claude-code-action@23e4ee05df2c5aefd801f51b83c81cd4215be7e9 # v1.0.120
+        uses: anthropics/claude-code-action@d2b7d924ec4af238380e490a0d57ce6bcc85ce8d # v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_commit_signing: true


### PR DESCRIPTION
## Summary
- bump both Claude workflows from v1.0.120 to v1.0.123
- use upstream fix for CLAUDE.md -> AGENTS.md symlink snapshot crashes

## Verification
- git diff --check origin/dev..HEAD
- upstream v1.0.123 tag object d2b7d924... dereferences symlinks when snapshotting sensitive paths